### PR TITLE
Fix EOF handling in Windows

### DIFF
--- a/serial/open_windows.go
+++ b/serial/open_windows.go
@@ -16,6 +16,7 @@ package serial
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"syscall"
@@ -136,7 +137,11 @@ func (p *serialPort) Read(buf []byte) (int, error) {
 	if err != nil && err != syscall.ERROR_IO_PENDING {
 		return int(done), err
 	}
-	return getOverlappedResult(p.fd, p.ro)
+	n, err := getOverlappedResult(p.fd, p.ro)
+	if n == 0 && err == nil {
+		return 0, io.EOF
+	}
+	return n, err
 }
 
 const PURGE_RXCLEAR = 0x8


### PR DESCRIPTION
Successful return with 0 bytes read is a EOF condition (e.g. due to timeout)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/go-serial/6)

<!-- Reviewable:end -->
