### PR TITLE
A workaround for CH340G driver on OS X

### DIFF
--- a/serial/open_darwin.go
+++ b/serial/open_darwin.go
@@ -95,6 +95,12 @@ func ioctl(fd, request, arg uintptr) error {
 		return errors.New("Unknown error from SYS_IOCTL.")
 	}
 
+	// This is a workaround for CH340G driver, which seems to not wait for
+	// USB_CONTROL calls to finish before returning. As a result, they may
+	// interleave with subsequent data transfers, which can wreak all sorts
+	// of havoc, changing baud rate and resetting FIFOs and whatnot.
+	time.Sleep(5 * time.Millisecond)
+
 	return nil
 }
 


### PR DESCRIPTION
It seems to not wait for USB_CONTROL calls to finish before returning.
As a result, they may interleave with subsequent data transfers, which
can wreak all sorts of havoc, changing baud rate and resetting FIFOs
and whatnot.

We add a short sleep after every ioctl() call. It seems to be sufficient
and is short enough to not matter much and be applied indiscriminately
to all platforms.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/go-serial/7)

<!-- Reviewable:end -->
