### PR TITLE
Linux does not have O_EXLOCK

### DIFF
--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -154,7 +154,7 @@ func openInternal(options OpenOptions) (Serial, error) {
 	file, openErr :=
 		os.OpenFile(
 			options.PortName,
-			syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK|syscall.O_EXCL|syscall.O_EXLOCK,
+			syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK|syscall.O_EXCL,
 			0600)
 	if openErr != nil {
 		return nil, openErr


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/go-serial/11)
<!-- Reviewable:end -->
